### PR TITLE
synok: limit number of jobs that can be scheduled at one time

### DIFF
--- a/synok/manifests/synok.yaml
+++ b/synok/manifests/synok.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: synok
 spec:
   schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/synok/manifests/synok.yaml
+++ b/synok/manifests/synok.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   schedule: "*/10 * * * *"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
fix(synok): set successfulJobsHistoryLimit and failedJobsHistoryLimit to 0, so completed and failed jobs do not store and concurrencyPolicy to Forbid, so new job will not start if existing one keeps running.

Closes #46